### PR TITLE
Changed the class of the options menu

### DIFF
--- a/extension/js/react/pages/settings/settings.jsx
+++ b/extension/js/react/pages/settings/settings.jsx
@@ -39,7 +39,7 @@ if (location.search.includes("rplus")) {
 	ReactDOM.render(<Settings />, container[0]);
 } else {
 	var li = $("<li class=\"menu-option\">");
-	var a = $("<a class=\"rbx-tab-heading\">").append($("<span class=\"font-caption-header\">").text(Extension.Singleton.manifest.name)).attr("href", Extension.Singleton.manifest.homepage_url);
+	var a = $("<a class=\"menu-option-content\">").append($("<span class=\"font-caption-header\">").text(Extension.Singleton.manifest.name)).attr("href", Extension.Singleton.manifest.homepage_url);
 	$("#vertical-menu").append(li.append(a));
 }
 


### PR DESCRIPTION
Changed from rbx-tab-heading to menu-options-content to make the Roblox+ menu more accessible. 
Before this patch, you could only access the Roblox+ menu by clicking on the text. 
Now you can access the Roblox+ menu by clicking anywhere on the tab in the options menu like any other tab.