### PR TITLE
Add locks to message listener

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,17 +14,6 @@
 		},
 		{
 			"type": "npm",
-			"script": "scss",
-			"problemMatcher": [
-				"$node-sass"
-			],
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		},
-		{
-			"type": "npm",
 			"script": "install"
 		}
 	]

--- a/src/css/pages/catalog.scss
+++ b/src/css/pages/catalog.scss
@@ -1,7 +1,0 @@
-.catalog-results {
-  .item-card {
-    &.creator-blocked {
-      display: none;
-    }
-  }
-}

--- a/src/css/pages/catalog.scss
+++ b/src/css/pages/catalog.scss
@@ -1,31 +1,7 @@
-.splash {
-	#rplus-featured-items {
-		margin-left: 6px;
-
-		.item-card {
-			display: inline-block;
-
-			&:nth-child(n+6) {
-				display: none;
-			}
-		}
-	}
-}
-
-:not(.splash) {
-	#rplus-featured-items {
-		margin-left: 6px;
-
-		.item-card:nth-child(n+7) {
-			display: none;
-		}
-	}
-}
-
 .catalog-results {
-	.item-card {
-		&.creator-blocked {
-			display: none;
-		}
-	}
+  .item-card {
+    &.creator-blocked {
+      display: none;
+    }
+  }
 }

--- a/src/js/jquery/Catalog.js
+++ b/src/js/jquery/Catalog.js
@@ -18,7 +18,7 @@ RPlus.Pages.Catalog = function () {
 							if (blocked) {
 								var itemCard = creatorLabel.closest(".item-card");
 								console.log(creatorLabel.text(), "is blocked - hiding item", itemCard);
-								itemCard.addClass("creator-blocked");
+								itemCard.addClass("hidden");
 							}
 						}).catch(console.error);
 					}

--- a/src/js/pages/catalog/index.ts
+++ b/src/js/pages/catalog/index.ts
@@ -1,1 +1,0 @@
-import '../../../css/pages/catalog.scss';

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -189,7 +189,6 @@
     },
 
     {
-      "js": ["/js/output/react/pages/catalog/featuredItems.js"],
       "css": ["dist/css/catalog.css"],
       "matches": ["*://*.roblox.com/catalog/*"],
       "run_at": "document_end"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -189,12 +189,6 @@
     },
 
     {
-      "css": ["dist/css/catalog.css"],
-      "matches": ["*://*.roblox.com/catalog/*"],
-      "run_at": "document_end"
-    },
-
-    {
       "js": ["./dist/pages/groups.js"],
       "css": ["./dist/css/groups.css"],
       "matches": [


### PR DESCRIPTION
# What :lock:

With #66, we introduced a `localizationService`, so that the feature that adds a "trade" link on the group wall posts of the [Trade.](https://www.roblox.com/groups/650266/Trade) group has translated text.

With this though, because multiple wall posts would get processed in parallel, it lead to multiple requests to the locale + translations API. To combat this, we introduced a cache, and then preloaded the translations, so the cache was hydrated. This was inefficient because it meant we would always load translation resources, even if we didn't need them.

# Solution :bulb:

Following the advice found on [stackoverflow](https://stackoverflow.com/a/73482349/1663648), we are now using the [navigator.locks](https://developer.mozilla.org/en-US/docs/Web/API/LockManager) API. This API allows us to take out a lock and ensure that multiple requests for translation resources don't get processed at the same time.

We have implemented this into the `messageService` as `levelOfParallelism`, where we allow it to be set to `1` to ensure only one message can be processed in parallel. `-1` disables this option (allowing unlimited messages to be processed in parallel. The reason for this implementation is that it allows us to change the implementation of the `messageService` later, and add an actual level of parallelism feature. But for now, this suites the use case.

# Unrelated :see_no_evil:

As part of this review, we found more code referencing sponsored items, which were removed with #67. We removed more code relating to this as a result of the extension not starting without doing this.

Also removed the `.vscode` task that was still there to compile scss, which is no longer relevant.