### PR TITLE
Remove remaining usages of webRequest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ dist
 
 # Custom
 src/js/output/
+src/_metadata/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ TODO: Fill this in with the next pull request, when there is actually settings i
 
 This thing has been updated to better support that manifest V3 thing I was talking about. Pretty much works the same as it did before, except you can't pick a sound for it anymore. Sorry.
 
+### :axe: Removed chrome.webRequest
+
+This update removed the remaining usages of one of the older chrome APIs that was being used by this extension: [chrome.webRequest](https://developer.chrome.com/docs/extensions/reference/webRequest). The remaining usages were replaced with [chrome.declarativeNetRequest](https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest), which is compatible with manifest V3.
+
 # 2.4.157
 
 good morning good morning good morning

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -66,6 +66,6 @@ The [extension manifest](https://github.com/roblox-plus/extension/blob/master/sr
 
 - [alarms](https://developer.chrome.com/docs/extensions/reference/alarms/): This one is used for the notifier features which execute in the background
 - [gcm](https://developer.chrome.com/docs/extensions/reference/gcm/), [notifications](https://developer.chrome.com/docs/extensions/reference/notifications/): These are used to send notifications to the browser extension
-- [webRequest](https://developer.chrome.com/docs/extensions/reference/webRequest/), [webRequestBlocking](https://developer.chrome.com/docs/extensions/reference/webRequest/), [declarativeNetRequest](https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/): These are used for the web request interception mentioned above
+- [declarativeNetRequest](https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/): This is used for the web request interception mentioned above
 - [tts](https://developer.chrome.com/docs/extensions/reference/tts/): Sometimes the notifications this extension sends speak when they are sent, and this permission is required for that
 - [storage](https://developer.chrome.com/docs/extensions/reference/storage/): The extension uses this one to store things like settings preferences

--- a/src/js/react/pages/settings/about.jsx
+++ b/src/js/react/pages/settings/about.jsx
@@ -330,7 +330,7 @@ class About extends React.Component {
 									</ul>
 								</li>
 								<li>
-									<span>webRequest (and webRequestBlocking)</span>
+									<span>declarativeNetRequest</span>
 									<ul>
 										<li>See Web Request Interception</li>
 									</ul>
@@ -366,7 +366,7 @@ class About extends React.Component {
 						<p class="text-description">
 							<span>Some requests to roblox.com are intercepted!</span>
 							<br />
-							<span>Yup. This extension uses webRequest and webRequestBlocking permissions to intercept and modify some requests that go to Roblox. For example: To load the authentication token for game launch additional headers are needed that are not typically accessible via XMLHttpRequest. webRequest is needed for this to add the additional request parameters necessary to launch you into game as... you!</span>
+							<span>Yup. This extension uses declarativeNetRequest permissions to intercept and modify some requests that go to Roblox. For example: To load the authentication token for game launch additional headers are needed that are not typically accessible via XMLHttpRequest. declarativeNetRequest is needed for this to add the additional request parameters necessary to launch you into game as... you!</span>
 							<br />
 							<span>There are other requests being intercepted (like knowing when you visit Roblox for the first time for the extension start notification when enabled) and I could list them all out but imagine being me for a second... what if I missed one? What if I add a new feature and forget to update the privacy policy? I don't know what's legally required or not. How much do I need to specify or forget to specify before Google pulls me off the chrome web store? Instead of me trying to go into the implementation details of every feature this extension has I invite you to the extensions source.</span>
 							<br />

--- a/src/js/rplus/settings.js
+++ b/src/js/rplus/settings.js
@@ -54,49 +54,26 @@ RPlus.Services.Settings = class extends Extension.BackgroundService {
 					}
 				}
 
-				let upload = `<roblox${encodeURIComponent(JSON.stringify(ns))}</roblox>`;
-				$.post(`https://data.roblox.com/Data/Upload.ashx?assetid=311113112&type=Model&length=${upload.length}`, upload).done((r) => {
+				fetch(`https://data.roblox.com/Data/Upload.ashx?assetid=311113112&type=Model`, {
+					method: 'POST',
+					headers: {
+						"Content-Type": "application/xml",
+						"Requester": "Client"
+					},
+					body: `<roblox${encodeURIComponent(JSON.stringify(ns))}</roblox>`
+				}).then(response => {
+					if (!response.ok) {
+						console.warn('Failed to upload asset', response);
+						reject('Failed to send request');
+					}
+
 					resolve(ns);
-				}).fail(Roblox.api.$reject(reject));
+				}).catch(reject);
 			}).catch(reject);
 		});
 	}
 };
 
 RPlus.settings = new RPlus.Services.Settings();
-
-if (Extension.Singleton.executionContextType == Extension.ExecutionContextTypes.background) {
-	/* Upload models with a post request */
-	chrome.webRequest.onBeforeSendHeaders.addListener(function (details) {
-		if (url.path(details.url) == "/Data/Upload.ashx") {
-			let newhead = [];
-			let headers = {
-				"User-Agent": "Roblox/WinInet",
-				"Host": "data.roblox.com",
-				"Accept": "*/*",
-				"Accept-Encoding": "deflate, gzip",
-				"Cookie": "",
-				"X-CSRF-TOKEN": "",
-				"Content-Type": "application/xml",
-				"Requester": "Client",
-				"Content-Length": url.param("length", details.url)
-			};
-
-			for (let n in details.requestHeaders) {
-				let na = details.requestHeaders[n].name;
-				if (headers.hasOwnProperty(na)) {
-					newhead.push({ name: na, value: headers[na] || details.requestHeaders[n].value });
-					delete headers[na];
-				}
-			}
-
-			for (let n in headers) {
-				newhead.push({ name: n, value: headers[n] });
-			}
-
-			return { requestHeaders: newhead };
-		}
-	}, { urls: ["*://data.roblox.com/Data/*"] }, ["requestHeaders", "blocking", "extraHeaders"]);
-}
 
 // WebGL3D

--- a/src/js/rplus/settings.js
+++ b/src/js/rplus/settings.js
@@ -54,21 +54,10 @@ RPlus.Services.Settings = class extends Extension.BackgroundService {
 					}
 				}
 
-				fetch(`https://data.roblox.com/Data/Upload.ashx?assetid=311113112&type=Model`, {
-					method: 'POST',
-					headers: {
-						"Content-Type": "application/xml",
-						"Requester": "Client"
-					},
-					body: `<roblox${encodeURIComponent(JSON.stringify(ns))}</roblox>`
-				}).then(response => {
-					if (!response.ok) {
-						console.warn('Failed to upload asset', response);
-						reject('Failed to send request');
-					}
-
+				const upload = `<roblox${encodeURIComponent(JSON.stringify(ns))}</roblox>`;
+				$.post(`https://data.roblox.com/Data/Upload.ashx?assetid=311113112&type=Model`, upload).done(() => {
 					resolve(ns);
-				}).catch(reject);
+				}).fail(Roblox.api.$reject(reject));
 			}).catch(reject);
 		});
 	}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -256,8 +256,6 @@
     "alarms",
     "gcm",
     "contextMenus",
-    "webRequest",
-    "webRequestBlocking",
     "declarativeNetRequest",
     "tts",
     "notifications",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -234,6 +234,16 @@
     }
   ],
 
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "upload_asset_rules",
+        "enabled": true,
+        "path": "upload-asset-rules.json"
+      }
+    ]
+  },
+
   "browser_action": {
     "default_icon": {
       "19": "/images/icons/icon_32x32.png"

--- a/src/upload-asset-rules.json
+++ b/src/upload-asset-rules.json
@@ -9,6 +9,16 @@
           "header": "User-Agent",
           "value": "Roblox/WinInet",
           "operation": "set"
+        },
+        {
+          "header": "Content-Type",
+          "value": "application/xml",
+          "operation": "set"
+        },
+        {
+          "header": "Requester",
+          "value": "Client",
+          "operation": "set"
         }
       ]
     },

--- a/src/upload-asset-rules.json
+++ b/src/upload-asset-rules.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 1,
+    "priority": 1,
+    "action": {
+      "type": "modifyHeaders",
+      "requestHeaders": [
+        {
+          "header": "User-Agent",
+          "value": "Roblox/WinInet",
+          "operation": "set"
+        }
+      ]
+    },
+    "condition": {
+      "urlFilter": "https://data.roblox.com/Data/Upload.ashx?assetid=311113112&type=Model",
+      "resourceTypes": ["xmlhttprequest"]
+    }
+  }
+]


### PR DESCRIPTION
# :1st_place_medal: What

This review removes the final usages of [chrome.webRequest](https://developer.chrome.com/docs/extensions/reference/webRequest), and replaces them with [chrome.declarativeNetRequest](https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest). This has been a long time coming, and pushes the extension a step closer to [manifest V3](https://developer.chrome.com/docs/extensions/mv3/manifest).

![image](https://github.com/roblox-plus/extension/assets/11600745/2caabe24-2f43-4dd4-a468-1e42c77ea490)
