### PR TITLE
Fix roblox.plus outside of chrome

### DIFF
--- a/libs/extension-messaging/src/index.ts
+++ b/libs/extension-messaging/src/index.ts
@@ -254,7 +254,7 @@ if (isBackgroundPage) {
     // https://stackoverflow.com/a/20077854/1663648
     return true;
   });
-} else if (chrome?.runtime) {
+} else if (globalThis.chrome?.runtime) {
   console.debug(
     `Not attaching listener for messages, because we're not in the background.`
   );
@@ -397,5 +397,5 @@ declare global {
 }
 
 export { getWorkerTab, sendMessageToTab } from './tabs';
+export { addListener, sendMessage };
 export type { MessageListener };
-export { sendMessage, addListener };

--- a/libs/extension-utils/src/constants/index.ts
+++ b/libs/extension-utils/src/constants/index.ts
@@ -1,6 +1,8 @@
-const manifest = chrome?.runtime?.getManifest() as chrome.runtime.ManifestV2;
+const manifest =
+  globalThis.chrome?.runtime?.getManifest() as chrome.runtime.ManifestV2;
 
 const isBackgroundPage =
-  chrome?.runtime?.getURL(manifest?.background?.page || '') === location.href;
+  globalThis.chrome?.runtime?.getURL(manifest?.background?.page || '') ===
+  location.href;
 
-export { manifest, isBackgroundPage };
+export { isBackgroundPage, manifest };


### PR DESCRIPTION
# :bug: What

[roblox.plus/settings](https://roblox.plus/settings) doesn't load if you're not using Google Chrome, and even though this is a Google Chrome extension.. it should load on other browsers too.