### PR TITLE
BUG: Fix extension on localized Roblox URLs

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,7 +28,7 @@
     {
       "js": ["dist/pages/all.js"],
       "css": ["dist/css/all.css"],
-      "matches": ["https://www.roblox.com/*", "https://web.roblox.com/*"],
+      "matches": ["https://www.roblox.com/*"],
       "run_at": "document_start"
     },
 
@@ -36,7 +36,7 @@
       "js": ["./dist/pages/avatar.js"],
       "matches": [
         "https://www.roblox.com/my/avatar",
-        "https://web.roblox.com/my/avatar"
+        "https://www.roblox.com/*/my/avatar"
       ],
       "run_at": "document_end"
     },
@@ -45,7 +45,7 @@
       "js": ["./dist/pages/messages.js"],
       "matches": [
         "https://www.roblox.com/my/messages*",
-        "https://web.roblox.com/my/messages*"
+        "https://www.roblox.com/*/my/messages*"
       ],
       "run_at": "document_end"
     },
@@ -55,7 +55,7 @@
       "js": ["./dist/pages/inventory.js"],
       "matches": [
         "https://www.roblox.com/users/*/inventory",
-        "https://web.roblox.com/users/*/inventory"
+        "https://www.roblox.com/*/users/*/inventory"
       ],
       "run_at": "document_end"
     },
@@ -65,7 +65,7 @@
       "css": ["./dist/css/games-list.css"],
       "matches": [
         "https://www.roblox.com/discover",
-        "https://web.roblox.com/discover"
+        "https://www.roblox.com/*/discover"
       ],
       "run_at": "document_end"
     },
@@ -75,7 +75,7 @@
       "css": ["./dist/css/groups.css"],
       "matches": [
         "https://www.roblox.com/groups/*/*",
-        "https://web.roblox.com/groups/*/*"
+        "https://www.roblox.com/*/groups/*/*"
       ],
       "run_at": "document_end"
     },
@@ -85,7 +85,7 @@
       "css": ["./dist/css/game-details.css"],
       "matches": [
         "https://www.roblox.com/games/*/*",
-        "https://web.roblox.com/games/*/*"
+        "https://www.roblox.com/*/games/*/*"
       ],
       "run_at": "document_end"
     },
@@ -94,7 +94,7 @@
       "js": ["./dist/pages/badge-details.js"],
       "matches": [
         "https://www.roblox.com/badges/*/*",
-        "https://web.roblox.com/badges/*/*"
+        "https://www.roblox.com/*/badges/*/*"
       ],
       "run_at": "document_end"
     },
@@ -103,7 +103,7 @@
       "js": ["./dist/pages/game-pass-details.js"],
       "matches": [
         "https://www.roblox.com/game-pass/*/*",
-        "https://web.roblox.com/game-pass/*/*"
+        "https://www.roblox.com/*/game-pass/*/*"
       ],
       "run_at": "document_end"
     },
@@ -113,7 +113,7 @@
       "css": ["dist/css/item-details.css"],
       "matches": [
         "https://www.roblox.com/catalog/*/*",
-        "https://web.roblox.com/catalog/*/*"
+        "https://www.roblox.com/*/catalog/*/*"
       ],
       "run_at": "document_end"
     },
@@ -122,7 +122,7 @@
       "js": ["./dist/pages/transactions.js"],
       "matches": [
         "https://www.roblox.com/transactions*",
-        "https://web.roblox.com/transactions*"
+        "https://www.roblox.com/*/transactions*"
       ],
       "run_at": "document_end"
     },
@@ -131,7 +131,7 @@
       "js": ["./dist/pages/profile.js"],
       "matches": [
         "https://www.roblox.com/users/*/profile*",
-        "https://web.roblox.com/users/*/profile*"
+        "https://www.roblox.com/*/users/*/profile*"
       ],
       "run_at": "document_end"
     },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -113,9 +113,7 @@
       "css": ["dist/css/item-details.css"],
       "matches": [
         "https://www.roblox.com/catalog/*/*",
-        "https://web.roblox.com/catalog/*/*",
-        "https://www.roblox.com/library/*/*",
-        "https://web.roblox.com/library/*/*"
+        "https://web.roblox.com/catalog/*/*"
       ],
       "run_at": "document_end"
     },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.1",
+  "version": "3.0.2",
   "name": "Roblox+",
   "short_name": "Roblox+",
   "description": "Extends the features available on roblox.com",


### PR DESCRIPTION
The extension doesn't work on pages like [this one](https://www.roblox.com/fr/games/17427651911/The-Classic), because the locale is in the URL path.

Also, `web.roblox.com` isn't valid anymore.